### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/languages/fr.json
+++ b/languages/fr.json
@@ -95,5 +95,6 @@
   "dorako-ui.settings.remove-attack-info-from-damage-roll-messages.name": "Retirer les infos de l'attaque des messages de jets de dégâts ?",
   "dorako-ui.settings.remove-attack-info-from-damage-roll-messages.hint": "Permet aux jets de dégâts de prendre moins de place en retirant les informations redondantes. Conçu pour être utilisé avec la fusion dans la conversation DFCE.",
   "dorako-ui.settings.no-chat-control-icon.name": "Cacher l'icone de contrôle de la conversation ?",
-  "dorako-ui.settings.no-chat-control-icon.hint": "C'est l'icône de dé à côté des options de lancer qui tend à encombrer l'IU."
+  "dorako-ui.settings.no-chat-control-icon.hint": "C'est l'icône de dé à côté des options de lancer qui tend à encombrer l'IU.",
+  "dorako-ui.settings.chat-input-height.CGMPhint": "La valeur par défaut de Foundry est d'environ 100px ; Notez qu'avec le paramètre \"Notifier la frappe\" du Cautious Gamemaster's Pack, la notification occupe au maximum 60px de la hauteur de la boîte de dialogue"
 }


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [PF2e Dorako UI/main](https://weblate.foundryvtt-hub.com/projects/pf2e-dorako-ui/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/pf2e-dorako-ui/-/main/horizontal-auto.svg)