### PR TITLE
Damage Target 1.4.0 Compatibility

### DIFF
--- a/styles/chat.css
+++ b/styles/chat.css
@@ -1739,6 +1739,14 @@ span[data-pf2-check].with-repost {
     padding: 0px 5px 5px 5px;
 }
 
+.hidden.right #target-damage-hide-button {
+    margin: 2px 0 0 0;
+}
+
+.hidden #target-damage-hide-button {
+    margin: 5px 0 0 0;
+}
+
 .pf2e.chat-card .card-header h3.pf2-icon {
     font-family: Pathfinder2eActions;
     font-size: xxx-large;


### PR DESCRIPTION
Turns this
![image](https://user-images.githubusercontent.com/32039708/209391452-9b7f6953-99af-4559-9f41-93d8d24c7747.png)
into this
![image](https://user-images.githubusercontent.com/32039708/209391570-30f0a05c-e42b-4a58-ac3c-c28138e8105f.png)
