### PR TITLE
exclude from theme api

### DIFF
--- a/modules/base-theme-hooks.js
+++ b/modules/base-theme-hooks.js
@@ -4,6 +4,9 @@ import { baseThemeApplications, baseThemePf2eSheets, MODULE_NAME, premiumModuleS
 for (const appName of [...baseThemeApplications]) {
   Hooks.on("render" + appName, (app, html, data) => {
     if (app.constructor.name.startsWith("SWPF")) return; // SWPFCompendiumTOC, SWPFSheet
+
+    // ? To bad this isn't an array, it would make it easier to manage, this may also match against more than its supposed to
+    // ? For example if a Module as a name of Windows but you exclude WindowsTabs, Both apps will match and be exlcuded.
     const excludeString = game.settings.get("pf2e-dorako-ui", "customization.excluded-applications");
     if (excludeString.toLowerCase().includes(appName.toLowerCase())) {
       console.debug(
@@ -11,6 +14,12 @@ for (const appName of [...baseThemeApplications]) {
       );
       return;
     }
+
+    // Get Array of Excluded Apps from API
+    const apiExcludedApps = game.modules.get(MODULE_NAME).api.excludedApplications;
+    // If AppName is in the array, do not add .dorako-ui
+    if (apiExcludedApps.includes(appName.toLowerCase())) return (console.debug(`${MODULE_NAME} | render${app.constructor.name} | is has been excluded via the api => do not add .dorako-ui`));
+
     let html0 = html[0];
     console.debug(`${MODULE_NAME} | baseThemeApplications | render${app.constructor.name} => add .dorako-ui`);
     // console.debug({ app });

--- a/modules/dark-theme-hooks.js
+++ b/modules/dark-theme-hooks.js
@@ -113,9 +113,17 @@ for (const app of ["Application", ...baseThemePf2eSheets]) {
       return;
     }
     if (!html0.classList.contains("app")) return;
+
+    // Get Array of Excluded Apps from API
+    const apiExcludedApps = game.modules.get(MODULE_NAME).api.excludedApplications;
+    // If AppName is in the array, do not add .dorako-ui
+    if (apiExcludedApps.includes(app.constructor.name.toLowerCase())) return (console.debug(`${MODULE_NAME} | render${app.constructor.name} | is has been excluded via the api => do not add .dorako-ui`));
+    
     console.debug(`${MODULE_NAME} | render${app.constructor.name} | theme: ${theme}`);
     html0.classList.add("dorako-ui");
-    html0.classList.add("dark-theme");
+
+    // If app.options.dorakoDarkTheme is not False, add .dark-theme
+    if (app?.options?.dorakoDarkTheme !== false) html0.classList.add("dark-theme");
   });
 }
 

--- a/modules/premium-module-hooks.js
+++ b/modules/premium-module-hooks.js
@@ -62,6 +62,12 @@ Hooks.on("renderApplication", (app, html, data) => {
   if (theme === "no-theme") {
     return;
   }
+
+  // Get Array of Excluded Apps from API
+  const apiExcludedApps = game.modules.get(MODULE_NAME).api.excludedApplications;
+  // If AppName is in the array, do not add .dorako-ui
+  if (apiExcludedApps.includes(app.constructor.name.toLowerCase())) return (console.debug(`${MODULE_NAME} | render${app.constructor.name} | has been excluded via the api => do not add .dorako-ui`));
+
   console.debug(`${MODULE_NAME} | render${app.constructor.name} | is .window-app => add .dorako-ui`);
   html0.classList.add("dorako-ui");
 });

--- a/modules/settings/settings.js
+++ b/modules/settings/settings.js
@@ -5,6 +5,7 @@ import { AvatarSettings } from "./avatar-settings.js";
 import { MiscSettings } from "./misc-settings.js";
 import { CustomizationSettings } from "./customization-settings.js";
 import { ExternalModuleSettings } from "./external-module-settings.js";
+import { MODULE_NAME } from "../consts.js";
 
 function injectCSS(filename) {
   const head = document.getElementsByTagName("head")[0];
@@ -56,6 +57,18 @@ Hooks.once("init", async () => {
   MiscSettings.registerSettings();
   CustomizationSettings.registerSettings();
   ExternalModuleSettings.registerSettings();
+
+  // Register API for Module
+  game.modules.get(MODULE_NAME).api = {
+    excludedApplications: [],
+    registerExcludeApplication: (constructorName) => {
+      // Get the current list of excluded applications as a set to avoid duplicates
+      // Conver to lowercase for case-insensitive comparison
+      let excludedApplications = new Set([...game.modules.get(MODULE_NAME).api.excludedApplications, constructorName.toLowerCase()]);
+      // Update the setting with the new set as an array
+      game.modules.get(MODULE_NAME).api.excludedApplications = Array.from(excludedApplications);
+    }
+  }
 
   util.debug("registered settings");
 

--- a/modules/sidebar-resizer.js
+++ b/modules/sidebar-resizer.js
@@ -213,7 +213,7 @@ Hooks.once("ready", function () {
       "WRAPPER"
     );
   } else {
-    console.warn(`${MODULE_NAME} | libwrapper not enabled, resizing of popped-out sidebars will be limited`);
+    console.warn(`pf2e-dorako-ui | libwrapper not enabled, resizing of popped-out sidebars will be limited`);
   }
 });
 


### PR DESCRIPTION
- added `game.modules.get('pf2e-dorako-ui').api.registerExcludeApplication('WindowTabs');` api call to exclude instances from recieving the `dorako-ui` class
- Added check for Windows to self exclude from dark mode. Include `dorakoDarkMode: false` when declaring your window settings to force window to never be in dark mode.
```js
new WindowTabs({
  id: `window-tabs-${collectionName}`,
  template: `modules/${MODULE.ID}/templates/window-tabs.hbs`,
  classes: ['window-tabs-app', `${MODULE.setting('cleanHeaderButtons') ? 'clean-header-buttons' : ''}`],
  resizable: true,
  height: height,
  width: sheetApp?.options?.width ?? 800, 
  dorakoDarkTheme: false
}).render(true);
```
