### PR TITLE
Fix compatibility with Force Client Settings

### DIFF
--- a/esmodules/settings/settings.js
+++ b/esmodules/settings/settings.js
@@ -51,7 +51,7 @@ Hooks.once("init", async () => {
   util.debug("initialized properties...");
 
   util.debug("Migrating invalid settings to default...");
-  const allSettings = [...game.settings.settings].filter(([k, _]) => k.includes(MODULE_NAME));
+  const allSettings = [...game.settings.settings].filter(([k, _]) => k.startsWith(MODULE_NAME));
   for (const [_, setting] of allSettings) {
     const key = setting.key;
     const currentValue = game.settings.get(MODULE_NAME, key);


### PR DESCRIPTION
Force Client Settings saves its settings with the module's name as part of the setting. When this module starts up and loops through all settings that include `pf2e-dorako-ui`. This causes errors in the console (and failing to continue the loop).

Changing this to `startsWith` will _only_ find the settings actually from this module.